### PR TITLE
removed some warnings when used with newer versions of Swift / Xcode toolchain

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,12 +21,10 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
-            name: "Segment",
             url: "https://github.com/segmentio/analytics-swift.git",
             from: "1.1.2"
         ),
         .package(
-            name: "Optimizely",
             url: "https://github.com/optimizely/swift-sdk.git",
             from: "3.10.1"
         )
@@ -36,9 +34,13 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SegmentOptimizelyFullStack",
-            dependencies: ["Segment", .product(
-                name: "Optimizely",
-                package: "Optimizely")]),
+            dependencies: [
+                .product(
+                    name: "Segment",
+                    package: "analytics-swift"),
+                .product(
+                    name: "Optimizely",
+                    package: "swift-sdk")]),
         
         // TESTS ARE HANDLED VIA THE EXAMPLE APP.
     ]

--- a/Sources/SegmentOptimizelyFullStack/OptimizelyFullStack.swift
+++ b/Sources/SegmentOptimizelyFullStack/OptimizelyFullStack.swift
@@ -81,7 +81,7 @@ public class OptimizelyFullStack: DestinationPlugin {
                 self.analytics?.log(message: "Received decision notification: \(type) \(userId) \(String(describing: attributes)) \(decisionInfo)")
                 let properties: [String: Any] = ["type": type,
                                                  "userId": userId,
-                                                 "attributes": attributes ?? [],
+                                                 "attributes": attributes ?? OptimizelyAttributes(),
                                                  "decisionInfo": decisionInfo]
                 
                 self.analytics?.track(name: "Experiment Viewed", properties: properties)


### PR DESCRIPTION
Some adjustments to remove warnings found when using Swift 5.8