### PR TITLE
fix: add revenue conversion for optimizely

### DIFF
--- a/Example/BasicExample/BasicExample/ContentView.swift
+++ b/Example/BasicExample/BasicExample/ContentView.swift
@@ -37,7 +37,10 @@ struct ContentView: View {
                 }).padding(6)
             }.padding(8)
         }.onAppear {
-            Analytics.main.track(name: "onAppear")
+            struct Properties: Codable {
+                let revenue: Int
+            }
+            Analytics.main.track(name: "onAppear", properties: Properties(revenue: 39))
             print("Executed Analytics onAppear()")
         }.onDisappear {
             Analytics.main.track(name: "onDisappear")


### PR DESCRIPTION
- Optimizely expects `revenue` to be represented in `cents` outlined [here](https://docs.developers.optimizely.com/experimentation-data/docs/event-api-troubleshooting#i-sent-events-with-revenue-values-through-the-api-but-the-revenue-is-not-calculated-correctly-on-the-results-page)
- adds check to convert revenue to a value optimizely expects
- resolves #10 